### PR TITLE
Rename the module to contain a /v2 suffix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/unravelin/go-jose
+module github.com/unravelin/go-jose/v2
 
 go 1.17
 


### PR DESCRIPTION
This is to facilitate the issuance of a new patch version (v2.6.1). This is being done manually as dependabot is struggling in unravelin/core:

https://github.com/unravelin/core/pull/13377