### PR TITLE
Rename all of the "internal" imports to use the /v2 suffix

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -28,8 +28,8 @@ import (
 	"fmt"
 	"math/big"
 
-	josecipher "github.com/unravelin/go-jose/cipher"
-	"github.com/unravelin/go-jose/json"
+	josecipher "github.com/unravelin/go-jose/v2/cipher"
+	"github.com/unravelin/go-jose/v2/json"
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/crypter.go
+++ b/crypter.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // Encrypter represents an encrypter which produces an encrypted JWE object.

--- a/cryptosigner/cryptosigner.go
+++ b/cryptosigner/cryptosigner.go
@@ -28,7 +28,7 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/unravelin/go-jose"
+	"github.com/unravelin/go-jose/v2"
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/cryptosigner/cryptosigner_test.go
+++ b/cryptosigner/cryptosigner_test.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/unravelin/go-jose"
+	"github.com/unravelin/go-jose/v2"
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/encoding.go
+++ b/encoding.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // Helper function to serialize known-good objects.

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/unravelin/go-jose"
+	"github.com/unravelin/go-jose/v2"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jose-util/utils.go
+++ b/jose-util/utils.go
@@ -21,7 +21,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/unravelin/go-jose"
+	"github.com/unravelin/go-jose/v2"
 )
 
 func LoadJSONWebKey(json []byte, pub bool) (*jose.JSONWebKey, error) {

--- a/jwe.go
+++ b/jwe.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // rawJSONWebEncryption represents a raw JWE JSON object. Used for parsing/serializing.

--- a/jwk-keygen/main.go
+++ b/jwk-keygen/main.go
@@ -30,7 +30,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"github.com/unravelin/go-jose"
+	"github.com/unravelin/go-jose/v2"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jwk.go
+++ b/jwk.go
@@ -36,7 +36,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // rawJSONWebKey represents a public or private key in JWK format, used for parsing/serializing.

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -37,7 +37,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // Test chain of two X.509 certificates

--- a/jws.go
+++ b/jws.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // rawJSONWebSignature represents a raw JWS JSON object. Used for parsing/serializing.

--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -21,9 +21,9 @@ import (
 	"bytes"
 	"reflect"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 
-	"github.com/unravelin/go-jose"
+	"github.com/unravelin/go-jose/v2"
 )
 
 // Builder is a utility for making JSON Web Tokens. Calls can be chained, and

--- a/jwt/builder_test.go
+++ b/jwt/builder_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/unravelin/go-jose"
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 type testClaims struct {

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // Claims represents public claim values (as specified in RFC 7519).

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -26,8 +26,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/unravelin/go-jose"
-	"github.com/unravelin/go-jose/jwt"
+	"github.com/unravelin/go-jose/v2"
+	"github.com/unravelin/go-jose/v2/jwt"
 )
 
 var sharedKey = []byte("secret")

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	jose "github.com/unravelin/go-jose"
-	"github.com/unravelin/go-jose/json"
+	jose "github.com/unravelin/go-jose/v2"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // JSONWebToken represents a JSON Web Token (as specified in RFC7519).

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	jose "github.com/unravelin/go-jose"
+	jose "github.com/unravelin/go-jose/v2"
 )
 
 var (

--- a/shared.go
+++ b/shared.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // KeyAlgorithm represents a key management algorithm.

--- a/signing.go
+++ b/signing.go
@@ -26,7 +26,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 // NonceSource represents a source of random nonces to go into JWS objects

--- a/signing_test.go
+++ b/signing_test.go
@@ -26,7 +26,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/unravelin/go-jose/json"
+	"github.com/unravelin/go-jose/v2/json"
 )
 
 type staticNonceSource string

--- a/symmetric.go
+++ b/symmetric.go
@@ -30,7 +30,7 @@ import (
 	"hash"
 	"io"
 
-	josecipher "github.com/unravelin/go-jose/cipher"
+	josecipher "github.com/unravelin/go-jose/v2/cipher"
 	"golang.org/x/crypto/pbkdf2"
 )
 


### PR DESCRIPTION
Commit 9eb9770e updated the module path, but it failed to update the corresponding imports. This commit fixes the problem.

The library appears to compile.